### PR TITLE
Fix undefined offset error in server load detection

### DIFF
--- a/wp-serverinfo.php
+++ b/wp-serverinfo.php
@@ -534,8 +534,10 @@ if(!function_exists('get_serverload')) {
             } else {
                 $data = @system('uptime');
                 preg_match('/(.*):{1}(.*)/', $data, $matches);
-                $load_arr = explode(',', $matches[2]);
-                $server_load = trim($load_arr[0]);
+                if( isset( $matches[2] ) ) {
+                    $load_arr = explode(',', $matches[2]);
+                    $server_load = trim($load_arr[0]);
+                }
             }
         }
         if(empty($server_load)) {


### PR DESCRIPTION
Check if `preg_match` captured `$matches[2]` before accessing it. When the uptime output doesn't match the regex pattern, the array index won't exist, causing `Notice: Undefined offset: 2`.

Fixes #11

Generated with [Claude Code](https://claude.ai/code)