### PR TITLE
Fix: handle null query cache size on MySQL 8

### DIFF
--- a/wp-serverinfo.php
+++ b/wp-serverinfo.php
@@ -490,7 +490,7 @@ if(!function_exists('get_mysql_query_cache_size')) {
         global $wpdb;
         $query_cache_size_query = $wpdb->get_row( "SHOW VARIABLES LIKE 'query_cache_size'" );
 
-        return $query_cache_size_query->Value;
+        return $query_cache_size_query ? $query_cache_size_query->Value : 0;
     }
 }
 


### PR DESCRIPTION
MySQL 8 removed query cache, so `SHOW VARIABLES LIKE 'query_cache_size'` returns no rows. Guard against null before accessing ->Value to prevent a PHP warning.

Fixes #9

Generated with [Claude Code](https://claude.ai/code)